### PR TITLE
Contributing: Add information about jekyll and translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 - This is the official handbook for Vanilla OS. It contains tutorials, guides and
 other information to help you get the most out of your Vanilla OS installation.
-- The handbook uses Jekyll for generating pages.
 - Thank you for your interest in our project. This guide will help you with writing and translating articles.
+- The handbook uses Jekyll for generating pages.
 
 ## Writing a guide
 
@@ -16,7 +16,7 @@ author field to have working links when the post is published.
 - Set the layout as
 `article`.
 - Headings must follow a proper hierarchy.
-- See [markdownlint](https://github.com/DavidAnson/markdownlint) for markdown best practices.
+- See [**markdownlint**](https://github.com/DavidAnson/markdownlint) for markdown best practices.
 - The guide must use the following structure at the beginning:
 
 ```md
@@ -46,6 +46,16 @@ and author names to your native language.
 article along with the original author names. 
 - Once you ensured that everything looks correct, open a new pull
 request for the translated guide.
+
+## Testing the guide locally using jekyll
+
+- You can install **jekyll** from this [page](https://jekyllrb.com/docs/installation/).
+- Clone your forked repository using `git` or `gh`. 
+- Add the guide to the correct destination in the cloned directory.
+- Run `jekyll build` to build the page to `./_site` once. Then you can either test the pages manually or use the `jekyll serve` command.
+- Run `jekyll serve` to build your site any time a source file changes and serve it locally.
+	- Navigate to `http://127.0.0.1:4000/` in your browser to preview and test the page.
+- Now, commit the changes using `git` and create a PR in GitHub.
 
 ## Discussions 
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ authors:
 ```
 
 - Add the link to your article in all `index` files with English titles and descriptions.
-- The `index` file will be replaced by the translated version of the page later.
+- The links in the `index` file will be replaced by the translated version of the page later.
 - Once you have ensured everything looks correct, open a new pull
 request for the guide.
 

--- a/README.md
+++ b/README.md
@@ -32,19 +32,29 @@ authors:
 ---
 ```
 
-- Once you ensured that everything looks correct, open a new pull
+- Add the link to your article in all `index` files with English titles and descriptions.
+- The `index` file will be replaced by the translated version of the page later.
+- Once you have ensured everything looks correct, open a new pull
 request for the guide.
+
+## Adding a language to Handbook
+
+-  Refer to 
+[**this page**](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) for language codes.
+- Create a directory named `_posts.ab`, where `ab` is your language code.
+- Create an index file named `index.ab.md` where `ab` is your language code.
+- Initially link the articles in the `index` to English pages in the `_posts` directory. When a translated page gets added, replace the current link with the translated page link in the respective `_posts.ab` directory, where `ab` is your language code.
 
 ## Translating a guide
 
 - If you want to translate an existing guide to your native language, you can add the translated
-article to the `_posts.ab` directory, where `ab` is your language code. Refer to 
-[this](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) page for language codes.
+article to the `_posts.ab` directory, where `ab` is your language code.
 - The filename must be in the format `YYYY-MM-DD-title.md`. Don't translate the layout
 and author names to your native language.
 - Add your GitHub username in the translated
-article along with the original author names. 
-- Once you ensured that everything looks correct, open a new pull
+article along with the original author names.
+- Replace the link in `index.ab` with your translated page, where `ab` is your language code.
+- Once you have ensured everything looks correct, open a new pull
 request for the translated guide.
 
 ## Testing the guide locally using jekyll
@@ -59,5 +69,4 @@ request for the translated guide.
 
 ## Discussions 
 
-Discussions regarding the handbook are done in the [official Discord server](https://discord.com/invite/34J8PFsk) in [#docs-writing](https://discord.com/channels/1023243680829681704/1035287786330263703).
-
+Discussions regarding the handbook are done in the [official Discord server](https://discord.com/invite/34J8PFsk) in [#docs-writing](https://discord.com/channels/1023243680829681704/1035287786330263703), and for Discussions regarding translations go to the [#translations](https://discord.com/channels/1023243680829681704/1037028192583692358) channel.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ request for the guide.
 -  Refer to 
 [**this page**](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) for language codes.
 - Create a directory named `_posts.ab`, where `ab` is your language code.
-- Create an index file named `index.ab.md` where `ab` is your language code.
+- Create an index file named `index.ab.md`, where `ab` is your language code.
 - Initially link the articles in the `index` to English pages in the `_posts` directory. When a translated page gets added, replace the current link with the translated page link in the respective `_posts.ab` directory, where `ab` is your language code.
 
 ## Translating a guide
@@ -69,4 +69,4 @@ request for the translated guide.
 
 ## Discussions 
 
-Discussions regarding the handbook are done in the [official Discord server](https://discord.com/invite/34J8PFsk) in [#docs-writing](https://discord.com/channels/1023243680829681704/1035287786330263703), and for Discussions regarding translations go to the [#translations](https://discord.com/channels/1023243680829681704/1037028192583692358) channel.
+Discussions regarding the handbook are done in the [**official Discord server**](https://discord.com/invite/34J8PFsk) in [`#docs-writing`](https://discord.com/channels/1023243680829681704/1035287786330263703), and for Discussions regarding translations go to the [`#translations`](https://discord.com/channels/1023243680829681704/1037028192583692358) channel.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ request for the translated guide.
 - Add the guide to the correct destination in the cloned directory.
 - Run `jekyll build` to build the page to `./_site` once. Then you can either test the pages manually or use the `jekyll serve` command.
 - Run `jekyll serve` to build your site any time a source file changes and serve it locally.
-	- Navigate to `http://127.0.0.1:4000/` or `https://localhost:4000` in your browser to preview and test the page.
+	- Navigate to `http://127.0.0.1:4000/` or `https://localhost:4000/` in your browser to preview and test the page.
 - Now, commit the changes using `git` and create a PR in GitHub.
 
 ## Discussions 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ request for the translated guide.
 - Add the guide to the correct destination in the cloned directory.
 - Run `jekyll build` to build the page to `./_site` once. Then you can either test the pages manually or use the `jekyll serve` command.
 - Run `jekyll serve` to build your site any time a source file changes and serve it locally.
-	- Navigate to `http://127.0.0.1:4000/` in your browser to preview and test the page.
+	- Navigate to `http://127.0.0.1:4000/` or `https://localhost:4000` in your browser to preview and test the page.
 - Now, commit the changes using `git` and create a PR in GitHub.
 
 ## Discussions 

--- a/_posts/2022-11-11-contributing.md
+++ b/_posts/2022-11-11-contributing.md
@@ -8,9 +8,8 @@ authors:
     - kra-mo
 ---
 
-
-- The handbook uses Jekyll for generating pages.
 - Thank you for your interest in our project. This guide will help you with writing and translating articles.
+- The handbook uses Jekyll for generating pages.
 
 ## Writing a guide
 
@@ -23,7 +22,7 @@ author field to have working links when the post is published.
 - Set the layout as
 `article`.
 - Headings must follow a proper hierarchy.
-- See [markdownlint](https://github.com/DavidAnson/markdownlint) for markdown best practices.
+- See [**markdownlint**](https://github.com/DavidAnson/markdownlint) for markdown best practices.
 - The guide must use the following structure at the beginning:
 
 ```md
@@ -53,6 +52,16 @@ and author names to your native language.
 article along with the original author names. 
 - Once you ensured that everything looks correct, open a new pull
 request for the translated guide.
+
+## Testing the guide locally using jekyll
+
+- You can install **jekyll** from this [page](https://jekyllrb.com/docs/installation/).
+- Clone your forked repository using `git` or `gh`. 
+- Add the guide to the correct destination in the cloned directory.
+- Run `jekyll build` to build the page to `./_site` once. Then you can either test the pages manually or use the `jekyll serve` command.
+- Run `jekyll serve` to build your site any time a source file changes and serve it locally.
+	- Navigate to `http://127.0.0.1:4000/` in your browser to preview and test the page.
+- Now, commit the changes using `git` and create a PR in GitHub.
 
 ## Discussions 
 

--- a/_posts/2022-11-11-contributing.md
+++ b/_posts/2022-11-11-contributing.md
@@ -48,7 +48,7 @@ request for the guide.
 -  Refer to 
 [**this page**](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) for language codes.
 - Create a directory named `_posts.ab`, where `ab` is your language code.
-- Create an index file named `index.ab.md` where `ab` is your language code.
+- Create an index file named `index.ab.md`, where `ab` is your language code.
 - Initially link the articles in the `index` to English pages in the `_posts` directory. When a translated page gets added, replace the current link with the translated page link in the respective `_posts.ab` directory, where `ab` is your language code.
 
 ## Translating a guide
@@ -75,5 +75,5 @@ request for the translated guide.
 
 ## Discussions 
 
-Discussions regarding the handbook are done in the [official Discord server](https://discord.com/invite/34J8PFsk) in [#docs-writing](https://discord.com/channels/1023243680829681704/1035287786330263703), and for Discussions regarding translations go to the [#translations](https://discord.com/channels/1023243680829681704/1037028192583692358) channel.
+Discussions regarding the handbook are done in the [**official Discord server**](https://discord.com/invite/34J8PFsk) in [`#docs-writing`](https://discord.com/channels/1023243680829681704/1035287786330263703), and for Discussions regarding translations go to the [`#translations`](https://discord.com/channels/1023243680829681704/1037028192583692358) channel.
 

--- a/_posts/2022-11-11-contributing.md
+++ b/_posts/2022-11-11-contributing.md
@@ -60,7 +60,7 @@ request for the translated guide.
 - Add the guide to the correct destination in the cloned directory.
 - Run `jekyll build` to build the page to `./_site` once. Then you can either test the pages manually or use the `jekyll serve` command.
 - Run `jekyll serve` to build your site any time a source file changes and serve it locally.
-	- Navigate to `http://127.0.0.1:4000/` or `https://localhost:4000` in your browser to preview and test the page.
+	- Navigate to `http://127.0.0.1:4000/` or `https://localhost:4000/` in your browser to preview and test the page.
 - Now, commit the changes using `git` and create a PR in GitHub.
 
 ## Discussions 

--- a/_posts/2022-11-11-contributing.md
+++ b/_posts/2022-11-11-contributing.md
@@ -60,7 +60,7 @@ request for the translated guide.
 - Add the guide to the correct destination in the cloned directory.
 - Run `jekyll build` to build the page to `./_site` once. Then you can either test the pages manually or use the `jekyll serve` command.
 - Run `jekyll serve` to build your site any time a source file changes and serve it locally.
-	- Navigate to `http://127.0.0.1:4000/` in your browser to preview and test the page.
+	- Navigate to `http://127.0.0.1:4000/` or `https://localhost:4000` in your browser to preview and test the page.
 - Now, commit the changes using `git` and create a PR in GitHub.
 
 ## Discussions 

--- a/_posts/2022-11-11-contributing.md
+++ b/_posts/2022-11-11-contributing.md
@@ -38,19 +38,29 @@ authors:
 ---
 ```
 
-- Once you ensured that everything looks correct, open a new pull
+- Add the link to your article in all `index` files with English titles and descriptions.
+- The `index` file will be replaced by the translated version of the page later.
+- Once you have ensured everything looks correct, open a new pull
 request for the guide.
+
+## Adding a language to Handbook
+
+-  Refer to 
+[**this page**](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) for language codes.
+- Create a directory named `_posts.ab`, where `ab` is your language code.
+- Create an index file named `index.ab.md` where `ab` is your language code.
+- Initially link the articles in the `index` to English pages in the `_posts` directory. When a translated page gets added, replace the current link with the translated page link in the respective `_posts.ab` directory, where `ab` is your language code.
 
 ## Translating a guide
 
 - If you want to translate an existing guide to your native language, you can add the translated
-article to the `_posts.ab` directory, where `ab` is your language code. Refer to 
-[this](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) page for language codes.
+article to the `_posts.ab` directory, where `ab` is your language code.
 - The filename must be in the format `YYYY-MM-DD-title.md`. Don't translate the layout
 and author names to your native language.
 - Add your GitHub username in the translated
-article along with the original author names. 
-- Once you ensured that everything looks correct, open a new pull
+article along with the original author names.
+- Replace the link in `index.ab` with your translated page, where `ab` is your language code.
+- Once you have ensured everything looks correct, open a new pull
 request for the translated guide.
 
 ## Testing the guide locally using jekyll
@@ -65,5 +75,5 @@ request for the translated guide.
 
 ## Discussions 
 
-Discussions regarding the handbook are done in the [official Discord server](https://discord.com/invite/34J8PFsk) in [#docs-writing](https://discord.com/channels/1023243680829681704/1035287786330263703).
+Discussions regarding the handbook are done in the [official Discord server](https://discord.com/invite/34J8PFsk) in [#docs-writing](https://discord.com/channels/1023243680829681704/1035287786330263703), and for Discussions regarding translations go to the [#translations](https://discord.com/channels/1023243680829681704/1037028192583692358) channel.
 


### PR DESCRIPTION
## Changes

1. Making some minor changes and tweaks. 
2. Adding a section about testing the Handbook locally using `jekyll`.
3. Adding information on creating a language directory.
4. Adding information on adding entries to the index.
5. Adding information about updating and maintaining the index in translation pages.
6. Adding a link to the translation channel.

Signed-off-by: K.B.Dharun Krishna <kbdharunkrishna@gmail.com>