### PR TITLE
Docker Guide: Update page for Debian

### DIFF
--- a/_posts/2023-02-05-install-docker.md
+++ b/_posts/2023-02-05-install-docker.md
@@ -53,7 +53,7 @@ echo \
 - Then run `sudo apt update` after its completion. After the update is complete, execute the following command:-
 
 ```bash
-sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+sudo apt install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 ```
 
 - Now, `exit` the transactional shell and `reboot` your system.

--- a/_posts/2023-02-05-install-docker.md
+++ b/_posts/2023-02-05-install-docker.md
@@ -32,7 +32,8 @@ sudo apt install \
     ca-certificates \
     curl \
     gnupg \
-    lsb-release
+    lsb-release \
+    apt-transport-https
 ```
 
 - Add Docker's GPG key using the following command:-

--- a/_posts/2023-02-05-install-docker.md
+++ b/_posts/2023-02-05-install-docker.md
@@ -31,28 +31,29 @@ sudo apt update
 sudo apt install \
     ca-certificates \
     curl \
-    gnupg \
-    lsb-release \
-    apt-transport-https
+    gnupg
 ```
 
 - Add Docker's GPG key using the following command:-
 
 ```bash
-sudo mkdir -p /etc/apt/keyrings
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+sudo mkdir -m 0755 -p /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/debian/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
 ```
 
 - Setup the repository using the following commands:-
 
 ```bash
-echo \ "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \ $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+echo \
+  "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
+  "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 ```
 
 - Then run `sudo apt update` after its completion. After the update is complete, execute the following command:-
 
 ```bash
-sudo apt install docker-ce docker-ce-cli containerd.io docker-compose-plugin
+sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 ```
 
 - Now, `exit` the transactional shell and `reboot` your system.
@@ -60,18 +61,11 @@ sudo apt install docker-ce docker-ce-cli containerd.io docker-compose-plugin
 
 **_Note_**:- Set the location for saved Images and Containers to `/home` to avoid filling up the root partition.
 
-Alternatively, you can install the Docker engine using the nix subcommand through the following steps:-
-
-```bash
-Initialize (One time step): apx init --nix
-Install Docker Engine: apx install --nix docker
-```
-
 ## Installing Docker Desktop
 
 You can install the Docker Desktop application using the following steps:-
 
-- First, download the DEB file from [**here**](https://docs.docker.com/desktop/install/ubuntu/).
+- First, download the DEB file from [**here**](https://docs.docker.com/desktop/install/debian/).
 - Then copy the file to `/tmp` (Temporary files in `/tmp` get removed after a reboot) using the command `cp -r docker-desktop-<version>-<arch>.deb /tmp` (Note:- `<>` is a placeholder, replace it with the correct details) in an unprivileged terminal session.
 - Then enter the transactional shell using the `sudo abroot shell` command.
 - Install the application using the following command:-


### PR DESCRIPTION
Add `apt-transport-https` package to avoid the following error on installing docker:

```
root@vanilla:/# sudo apt update
Running in chroot, ignoring command 'start'
Hit:1 http://archive.ubuntu.com/ubuntu kinetic InRelease
Hit:2 http://archive.ubuntu.com/ubuntu kinetic-updates InRelease               
Hit:3 http://ppa.launchpad.net/vanilla-os/stable/ubuntu kinetic InRelease      
Ign:4 https://download.docker.com/linux/ubuntu \ InRelease                     
Err:5 https://download.docker.com/linux/ubuntu \ Release         
  404  Not Found [IP: 18.164.6.56 443]
Hit:6 https://ppa.launchpadcontent.net/appimagelauncher-team/stable/ubuntu kinetic InRelease
Reading package lists... Done                              
E: The repository 'https://download.docker.com/linux/ubuntu \ Release' does not have a Release file.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
```