### PR TITLE
fix: solve a problem installing docker with abroot

### DIFF
--- a/_posts/2023-02-05-install-docker.md
+++ b/_posts/2023-02-05-install-docker.md
@@ -6,6 +6,7 @@ layout: article
 authors: 
     - kbdharun
     - zedtux
+    - Phosphorus-M
 published: true
 ---
 
@@ -46,7 +47,7 @@ curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o 
 Setup the repository using the following commands:-
 
 ```bash
-echo \ "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \ $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+echo \ "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 ```
 
 Then run `sudo apt update` after its completion. After the update is complete, execute the following command:-


### PR DESCRIPTION
I changed the line to execute because it was getting troubles, with this change all works fine.
The proof:

![image](https://github.com/Vanilla-OS/handbook/assets/19656993/4c7ac20d-5e3a-4ee6-8189-77601844a379)

